### PR TITLE
Convenient access, construction and conversion

### DIFF
--- a/nip/__init__.py
+++ b/nip/__init__.py
@@ -1,7 +1,6 @@
 from .constructor import Constructor
 from .constructor import nip, wrap_module
 from .convertor import pin
-from .elements import Element
 from .main import (
     parse,
     parse_string,
@@ -13,5 +12,6 @@ from .main import (
     convert,
     run,
 )
+from .elements import Node
 from .non_seq_constructor import NonSequentialConstructor
 from .parser import Parser

--- a/nip/constructor.py
+++ b/nip/constructor.py
@@ -64,13 +64,13 @@ class NIPBuilder:
     pass
 
 
-def nip_decorator(name=None, wrap_call=False):
+def nip_decorator(name=None, convertable=False):
     assert name is None or len(name) > 0, "name should be nonempty"
 
     def _(item):
-        if wrap_call:
+        if convertable:
             assert isinstance(item, type), "Call wrapping supported only for class type"
-            item = call_wrapper(item)
+            make_convertable(item)
         local_name = name or item.__name__
         if isinstance(local_name, (list, tuple)):
             for n in local_name:
@@ -83,41 +83,24 @@ def nip_decorator(name=None, wrap_call=False):
 
 
 # instead of multipledispatch
-def nip(item=None, *, wrap_builtins=False, wrap_call=False):
+def nip(item=None, *, wrap_builtins=False, convertable=False):
     if isinstance(item, str):  # single name is passed
-        return nip_decorator(item, wrap_call)
+        return nip_decorator(item, convertable)
     if isinstance(item, (list, tuple)):
         for name in item:
             if not isinstance(name, str):
                 raise ValueError("Every specified Tag should be a string.")
-        return nip_decorator(item, wrap_call)
+        return nip_decorator(item, convertable)
     if isinstance(item, (type, FunctionType, BuiltinFunctionType)):
-        return nip_decorator()(item)
+        return nip_decorator(convertable=convertable)(item)
     if isinstance(item, ModuleType):
-        return wrap_module(item, wrap_builtins)
+        return wrap_module(item, wrap_builtins=wrap_builtins, convertable=convertable)
     if item is not None:
         raise ValueError("Unexpected type passed to @nip decorator.")
-    return nip_decorator(wrap_call=wrap_call)
+    return nip_decorator(convertable=convertable)
 
 
-def call_wrapper(item: Union[type, FunctionType]):  # wraps call for convenient object dump
-    print("wrapping")
-
-    # ToDo: only for classes !!
-
-    def call_dumper(*args, **kwargs):
-        print(args, kwargs)
-        value = item(*args, **kwargs)
-        global_calls[value] = (args, kwargs)  # Todo: how to do this correctly?
-        return value
-
-    call_dumper.__doc__ = item.__doc__  # mimic to original function
-    call_dumper.__name__ = item.__name__
-
-    return call_dumper
-
-
-def wrap_module(module: Union[str, ModuleType], wrap_builtins=False):
+def wrap_module(module: Union[str, ModuleType], wrap_builtins=False, convertable=False):
     """Wraps everything declared in module with @nip
 
     Parameters
@@ -133,6 +116,29 @@ def wrap_module(module: Union[str, ModuleType], wrap_builtins=False):
 
     for value in module.__dict__.values():
         if isinstance(value, (type, FunctionType)) or wrap_builtins and isinstance(value, BuiltinFunctionType):
-            nip(value)
+            nip(value, convertable=convertable and isinstance(value, type))
 
     return module
+
+
+class ArgsKwargs:
+    def __init__(self, args, kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def _wrap_init_call(self, *args, **kwargs):
+    self.__init_args = ArgsKwargs(args, kwargs)
+    self.__origin_init__(*args, **kwargs)
+
+
+def _converter(self):
+    return self.__init_args
+
+
+def make_convertable(cls):
+    if hasattr(cls, "__nip__"):
+        return
+    cls.__origin_init__ = cls.__init__
+    cls.__init__ = _wrap_init_call
+    cls.__nip__ = _converter

--- a/nip/constructor.py
+++ b/nip/constructor.py
@@ -20,7 +20,7 @@ class Constructor:
         self.strict_typing = strict_typing
 
     def construct(self, element):
-        return element.construct(self)
+        return element._construct(self)
 
     def register(self, func: Callable, tag: Optional[str] = None):
         """Registers builder function for tag
@@ -45,7 +45,7 @@ class Constructor:
 class ConstructorError(Exception):
     def __init__(self, element, args, kwargs, e):
         self.cls = type(element).__name__
-        self.name = element.name
+        self.name = element._name
         self.args = args
         self.kwargs = kwargs
         self.e = e

--- a/nip/convertor.py
+++ b/nip/convertor.py
@@ -1,6 +1,6 @@
 from typing import Optional, Callable, Union
 
-from nip.constructor import global_builders
+from nip.constructor import global_builders, ArgsKwargs
 from nip.elements import Node, Args, Tag, Value
 
 global_convertors = {}
@@ -20,6 +20,11 @@ class Convertor:
 
         if hasattr(obj, "__nip__"):
             return Tag(class_name, self.convert(obj.__nip__()))
+
+        if isinstance(obj, ArgsKwargs):
+            args = [self.convert(value) for value in obj.args]
+            kwargs = {key: self.convert(value) for key, value in obj.kwargs.items()}
+            return Args("args", (args, kwargs))
 
         if isinstance(obj, dict):
             kwargs = {}

--- a/nip/convertor.py
+++ b/nip/convertor.py
@@ -1,7 +1,7 @@
 from typing import Optional, Callable, Union
 
 from nip.constructor import global_builders
-from nip.elements import Element, Args, Tag, Value
+from nip.elements import Node, Args, Tag, Value
 
 global_convertors = {}
 
@@ -12,7 +12,7 @@ class Convertor:
         if load_globals:
             self._load_globals()
 
-    def convert(self, obj: object) -> Element:
+    def convert(self, obj: object) -> Node:
         class_name = type(obj).__name__
         if class_name in self.convertors:
             tag, convertor = self.convertors[class_name]

--- a/nip/directives.py
+++ b/nip/directives.py
@@ -13,17 +13,17 @@ def insert_directive(right_value, stream: Stream):
         assert isinstance(path, str), "Load directive expects path as an argument."
         parser = Parser()
         config = parser.parse(path)  # Document
-        return config.value
+        return config._value
 
     elif isinstance(right_value, nip.elements.Args):
-        assert len(right_value.value[0]) == 1, "only single positional argument will be treated as config path."
+        assert len(right_value._value[0]) == 1, "only single positional argument will be treated as config path."
         constructor = Constructor()
-        path = constructor.construct(right_value.value[0][0])
+        path = constructor.construct(right_value._value[0][0])
         assert isinstance(path, str), "Load directive expects path as first argument."
         parser = Parser()
-        parser.link_replacements = right_value.value[1]
+        parser.link_replacements = right_value._value[1]
         config = parser.parse(path)  # Document
-        return config.value
+        return config._value
 
     else:
         raise ParserError(

--- a/nip/dumper.py
+++ b/nip/dumper.py
@@ -10,10 +10,10 @@ class Dumper:
         self.create_dirs = create_dirs
 
     def dumps(self, element):
-        return element.dump(self).strip()
+        return element._dump(self).strip()
 
     def dump(self, filepath: Union[str, Path], element):
-        string = element.dump(self).strip()
+        string = element._dump(self).strip()
         filepath = Path(filepath)
         if self.create_dirs:
             filepath.parent.mkdir(parents=True, exist_ok=True)

--- a/nip/elements.py
+++ b/nip/elements.py
@@ -393,6 +393,13 @@ class Args(Node):
     def __setitem__(self, key, value):
         value = nip.convert(value)
         if isinstance(key, int):
+            if not -1 <= key < len(self._value[0]):
+                raise KeyError(
+                    f"You can only access existing positional arguments or add new one using -1 key. "
+                    f"Index {key} is out of range [-1, {len(self._value[0]) - 1}]."
+                )
+            if key == -1:
+                self._value[0].append(value)
             self._value[0][key] = value
         else:
             self._value[1][key] = value

--- a/nip/elements.py
+++ b/nip/elements.py
@@ -1,8 +1,10 @@
 """Contains all the elements of nip config files"""
+
 from __future__ import annotations
 
 import logging
 from abc import abstractmethod, ABC
+from pathlib import Path
 from typing import Any, Union, Tuple, Dict
 
 import nip.constructor  # This import pattern because of cycle imports
@@ -17,48 +19,96 @@ import nip.utils
 _LOGGER = logging.getLogger(__name__)
 
 
-class Element(ABC):
+class Node(ABC, object):
     """Base token for nip file"""
 
-    def __init__(self, name: str = "", value: Union[Element, Any] = None):
-        self.name = name
-        self.value = value
+    def __init__(self, name: str = "", value: Union[Node, Any] = None):
+        self._name = name
+        self._value = value
+        self._parent = None
 
     @classmethod
     @abstractmethod
-    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Element, None]:
+    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Node, None]:
         pass
 
     def __str__(self):
-        return f"{self.__class__.__name__}('{self.name}', {self.value})"
+        return f"{self.__class__.__name__}('{self._name}', {self._value})"
 
     def __getitem__(self, item):
-        return self.value[item]
+        if not isinstance(item, (str, int)):
+            raise KeyError(f"Unexpected item type: {type(item)}")
+        if isinstance(item, str) and len(item) == 0:
+            return self
+        return self._value[item]
+
+    def __getattr__(self, item):
+        return self.__getitem__(item)
 
     def __setitem__(self, key, value):
-        self.value[key] = value
+        self._value[key] = value
+        self._value._parent = self
+
+    def __setattr__(self, key, value):
+        if key.startswith("_"):  # mb: ensure not user's node name?
+            self.__dict__[key] = value
+        else:
+            self.__setitem__(key, value)
 
     def to_python(self):
-        return self.value.to_python()
+        return self._value.to_python()
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        return self.value.construct(constructor)
+    def _construct(self, constructor: nip.constructor.Constructor):
+        return self._value._construct(constructor)
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return self.value.dump(dumper)
+    def construct(self, base_config: Node = None, strict_typing: bool = False, nonsequential: bool = True):
+        return nip.construct(self, base_config=base_config, strict_typing=strict_typing, nonsequential=nonsequential)
+
+    @property
+    def value(self):
+        return self.construct()
+
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return self._value._dump(dumper)
+
+    def dump(self, path: Union[str, Path]):
+        nip.dump(path, self)
+
+    def dump_string(self):
+        return nip.dump_string(self)
 
     def __eq__(self, other):
-        return self.name == other.name and self.value == other.value
+        return self._name == other._name and self._value == other._value
 
     def flatten(self, delimiter=".") -> Dict:
         return nip.utils.flatten(self.to_python(), delimiter)
 
+    def _update_parents(self):
+        if isinstance(self._value, Node):
+            self._value._parent = self
+            self._value._update_parents()
 
-class Document(Element):  # ToDo: add multi document support
+    def _get_root(self):
+        if self._parent is None:
+            return self
+        return self._parent._get_root()
+
+    def update(self):
+        self._get_root().update()
+
+
+Element = Node  # backward compatibility until 1.* version
+
+
+class Document(Node):  # ToDo: add multi document support
+    def __init__(self, name: str = "", value: Union[Node, Any] = None):
+        super().__init__(name, value)
+        self._path = None
+
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Document:
         doc_name = cls._read_name(stream)
-        content = RightValue.read(stream, parser)
+        content = read_node(stream, parser)
         return Document(doc_name, content)
 
     @classmethod
@@ -67,40 +117,20 @@ class Document(Element):  # ToDo: add multi document support
         if read_tokens is not None:
             stream.step()
             if len(read_tokens) == 2:
-                return read_tokens[1].value
+                return read_tokens[1]._value
         return ""
 
-    def dump(self, dumper: nip.dumper.Dumper):
+    def _dump(self, dumper: nip.dumper.Dumper):
         string = "---"
-        if self.name:
-            string += " " + self.name + " "
-        return string + self.value.dump(dumper)
+        if self._name:
+            string += " " + self._name + " "
+        return string + self._value._dump(dumper)
+
+    def update(self):
+        self.dump(self._path)
 
 
-class RightValue(Element):
-    @classmethod
-    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Element:
-        value = (
-            Directive.read(stream, parser)
-            or LinkCreation.read(stream, parser)
-            or Link.read(stream, parser)
-            or Class.read(stream, parser)
-            or Tag.read(stream, parser)
-            or Iter.read(stream, parser)
-            or Args.read(stream, parser)
-            or FString.read(stream, parser)
-            or Nothing.read(stream, parser)
-            or InlinePython.read(stream, parser)
-            or Value.read(stream, parser)
-        )
-
-        if value is None:
-            raise nip.parser.ParserError(stream, "Wrong right value")
-
-        return value
-
-
-class Value(Element):
+class Value(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[None, Value]:
         tokens_list = [
@@ -115,28 +145,28 @@ class Value(Element):
             read_tokens = stream.peek(token)
             if read_tokens is not None:
                 stream.step()
-                return Value(read_tokens[0].name, read_tokens[0].value)
+                return Value(read_tokens[0]._name, read_tokens[0]._value)
 
         return None
 
     def to_python(self):
-        return self.value
+        return self._value
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        return self.value
+    def _construct(self, constructor: nip.constructor.Constructor = None):
+        return self._value
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        if isinstance(self.value, str):
-            return f'"{self.value}"'
-        return str(self.value)
+    def _dump(self, dumper: nip.dumper.Dumper):
+        if isinstance(self._value, str):
+            return f'"{self._value}"'
+        return str(self._value)
 
     def __len__(self):
-        return len(self.value)
+        return len(self._value)
 
 
-class LinkCreation(Element):
+class LinkCreation(Node):
     @classmethod
-    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Element, None]:
+    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Node, None]:
         read_tokens = stream.peek(tokens.Operator("&"), tokens.Name)
         if read_tokens is None:
             # if stream.peek(tokens.Operator('&')):  # mb: do it more certainly: peak operator
@@ -144,33 +174,33 @@ class LinkCreation(Element):
             #         stream, "Found variable creation operator '&' but name is not specified")
             return None
 
-        name = read_tokens[1].value
+        name = read_tokens[1]._value
         stream.step()
 
-        value = RightValue.read(stream, parser)
+        value = read_node(stream, parser)
         if name in parser.links:
             raise nip.parser.ParserError(stream, f"Redefining of link '{name}'")
         parser.links.append(name)
 
         return LinkCreation(name, value)
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        if nsc.should_construct(self.name, constructor):
-            constructor.vars[self.name] = self.value.construct(constructor)
-        return constructor.vars[self.name]
+    def _construct(self, constructor: nip.constructor.Constructor):
+        if nsc.should_construct(self._name, constructor):
+            constructor.vars[self._name] = self._value._construct(constructor)
+        return constructor.vars[self._name]
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return f"&{self.name} {self.value.dump(dumper)}"
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return f"&{self._name} {self._value._dump(dumper)}"
 
 
-class Link(Element):
+class Link(Node):
     @classmethod
-    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Element, None]:
+    def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Node, None]:
         read_tokens = stream.peek(tokens.Operator("*"), tokens.Name)
         if read_tokens is None:
             return None
 
-        name = read_tokens[1].value
+        name = read_tokens[1]._value
         stream.step()
 
         if name in parser.link_replacements:
@@ -184,86 +214,86 @@ class Link(Element):
     def to_python(self):
         return "nil"  # something that means that object is not constructed yet.
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        return constructor.vars[self.name]
+    def _construct(self, constructor: nip.constructor.Constructor):
+        return constructor.vars[self._name]
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return f"*{self.name}"
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return f"*{self._name}"
 
 
-class Tag(Element):
+class Tag(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Tag, None]:
         read_tokens = stream.peek(tokens.Operator("!"), tokens.Name)
         if read_tokens is None:
             return None
-        name = read_tokens[1].value
+        name = read_tokens[1]._value
         stream.step()
 
-        value = RightValue.read(stream, parser)
+        value = read_node(stream, parser)
 
         return Tag(name, value)
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        if isinstance(self.value, Args):
-            args, kwargs = self.value.construct(constructor, always_pair=True)
+    def _construct(self, constructor: nip.constructor.Constructor):
+        if isinstance(self._value, Args):
+            args, kwargs = self._value._construct(constructor, always_pair=True)
         else:
-            value = self.value.construct(constructor)
+            value = self._value._construct(constructor)
             if isinstance(value, Nothing):  # mb: Add IS_NOTHING method
-                return constructor.builders[self.name]()
+                return constructor.builders[self._name]()
             else:
                 args, kwargs = [value], {}
 
-        if self.name not in constructor.builders:
+        if self._name not in constructor.builders:
             raise nip.constructor.ConstructorError(
                 self,
                 args,
                 kwargs,
-                f"Constructor for Tag '{self.name}' is not registered.",
+                f"Constructor for Tag '{self._name}' is not registered.",
             )
 
-        messages = nip.utils.check_typing(constructor.builders[self.name], args, kwargs)
+        messages = nip.utils.check_typing(constructor.builders[self._name], args, kwargs)
         if len(messages) > 0:
             if constructor.strict_typing:
                 raise nip.constructor.ConstructorError(self, args, kwargs, "\n".join(messages))
             else:
-                _LOGGER.warning(f"Typing mismatch while constructing {self.name}:\n" + "\n".join(messages))
+                _LOGGER.warning(f"Typing mismatch while constructing {self._name}:\n" + "\n".join(messages))
 
         try:  # Try to construct
-            return constructor.builders[self.name](*args, **kwargs)
+            return constructor.builders[self._name](*args, **kwargs)
         except Exception as e:
             raise nip.constructor.ConstructorError(self, args, kwargs, e)
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return f"!{self.name} " + self.value.dump(dumper)
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return f"!{self._name} " + self._value._dump(dumper)
 
 
-class Class(Element):
+class Class(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Class, None]:
         read_tokens = stream.peek(tokens.Operator("!&"), tokens.Name)
         if read_tokens is None:
             return None
-        name = read_tokens[1].value
+        name = read_tokens[1]._value
         stream.step()
 
-        value = RightValue.read(stream, parser)
+        value = read_node(stream, parser)
         if not isinstance(value, Nothing):
             raise nip.parser.ParserError(stream, "Class should be created with nothing to the right.")
 
         return Class(name, value)
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        value = self.value.construct(constructor)
+    def _construct(self, constructor: nip.constructor.Constructor):
+        value = self._value._construct(constructor)
         assert isinstance(value, Nothing), "Unexpected right value while constructing Class"
 
-        return constructor.builders[self.name]
+        return constructor.builders[self._name]
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return f"!&{self.name} " + self.value.dump(dumper)
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return f"!&{self._name} " + self._value._dump(dumper)
 
 
-class Args(Element):
+class Args(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Args, None]:
         start_indent = stream.pos
@@ -271,7 +301,7 @@ class Args(Element):
             return None
 
         args = []
-        kwargs = {}  # mb: just dict with integer and string keys
+        kwargs = {}  # mb: just dict with integer and string keys !
         read_kwarg = False
         while stream and stream.pos == start_indent:
             parser.last_indent = start_indent
@@ -281,7 +311,7 @@ class Args(Element):
                 if parser.strict and read_kwarg:
                     raise nip.parser.ParserError(
                         stream,
-                        "Positional argument after keyword argument " "is forbiddent in `strict` mode.",
+                        "Positional argument after keyword argument is forbidden in `strict` mode.",
                     )
                 args.append(item)
                 continue
@@ -302,27 +332,27 @@ class Args(Element):
         return Args("args", (args, kwargs))
 
     @classmethod
-    def _read_list_item(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Element, None]:
+    def _read_list_item(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Node, None]:
         read_tokens = stream.peek(tokens.Operator("- "))
         if read_tokens is None:
             return None
         stream.step()
 
-        value = RightValue.read(stream, parser)
+        value = read_node(stream, parser)
 
         return value
 
     @classmethod
     def _read_dict_pair(
         cls, stream: nip.stream.Stream, parser: nip.parser.Parser, kwargs_keys
-    ) -> Union[Tuple[str, Element], Tuple[None, None]]:
+    ) -> Union[Tuple[str, Node], Tuple[None, None]]:
         # mb: read String instead of Name for keys with spaces,
         # mb: but this leads to the case that
         read_tokens = stream.peek(tokens.Name, tokens.Operator(": "))
         if read_tokens is None:
             return None, None
 
-        key = read_tokens[0].value
+        key = read_tokens[0]._value
         if parser.strict and key in kwargs_keys:
             raise nip.parser.ParserError(
                 stream,
@@ -330,46 +360,62 @@ class Args(Element):
             )
         stream.step()
 
-        value = RightValue.read(stream, parser)
+        value = read_node(stream, parser)
 
         return key, value
 
     def __str__(self):
-        args_repr = "[" + ", ".join([str(item) for item in self.value[0]]) + "]"
-        kwargs_repr = "{" + ", ".join([f"{key}: {str(value)}" for key, value in self.value[1].items()]) + "}"
+        args_repr = "[" + ", ".join([str(item) for item in self._value[0]]) + "]"
+        kwargs_repr = "{" + ", ".join([f"{key}: {str(value)}" for key, value in self._value[1].items()]) + "}"
 
-        return f"{self.__class__.__name__}('{self.name}', {args_repr}, {kwargs_repr})"
+        return f"{self.__class__.__name__}('{self._name}', {args_repr}, {kwargs_repr})"
 
     def __bool__(self):
-        return bool(self.value[0]) or bool(self.value[1])
+        return bool(self._value[0]) or bool(self._value[1])
 
     def __getitem__(self, item):
-        try:
-            return self.value[0][item]
-        except TypeError:
-            return self.value[1][item]
+        if not isinstance(item, (str, int)):
+            raise KeyError(f"Unexpected item type: {type(item)}")
+        if isinstance(item, str) and len(item) == 0:
+            return self
+        if isinstance(item, int):
+            return self._value[0][item]
+        key = None
+        for key in self._value[1]:
+            if item.startswith(key):
+                break
+        if not item.startswith(key):
+            raise KeyError(f"'{item}' is not a part of the Node.")
+        if len(item) == len(key):
+            return self._value[1][key]
+        if item[len(key)] != ".":
+            raise KeyError(f"items should be separated by a dot '.'.")
+
+        item = item[len(key) + 1 :]
+        return self._value[1][key][item]
 
     def __setitem__(self, key, value):
+        value = nip.convert(value)
         if isinstance(key, int):
-            self.value[0][key] = nip.convert(value)
+            self._value[0][key] = value
         else:
-            self.value[1][key] = nip.convert(value)
+            self._value[1][key] = value
 
     def append(self, value):
-        self.value[0].append(nip.convert(value))
+        self._value[0].append(nip.convert(value))
 
     def __len__(self):
-        return len(self.value[0]) + len(self.value[1])
+        return len(self._value[0]) + len(self._value[1])
 
     def __iter__(self):
-        for item in self.value[0]:
+        for item in self._value[0]:
             yield item
-        for key, item in self.value[1].items():
+        for key, item in self._value[1].items():
             yield item
 
     def to_python(self):
-        args = list(item.to_python() for item in self.value[0])
-        kwargs = {key: value.to_python() for key, value in self.value[1].items()}
+        args = list(item.to_python() for item in self._value[0])
+        kwargs = {key: value.to_python() for key, value in self._value[1].items()}
         assert args or kwargs, "Error converting Args node to python"  # This should never happen
         if args and kwargs:
             result = {}
@@ -378,35 +424,41 @@ class Args(Element):
             return result
         return args or kwargs
 
-    def construct(self, constructor: nip.constructor.Constructor, always_pair=False):
-        args = list(item.construct(constructor) for item in self.value[0])
-        kwargs = {key: value.construct(constructor) for key, value in self.value[1].items()}
+    def _construct(self, constructor: nip.constructor.Constructor, always_pair=False):
+        args = list(item._construct(constructor) for item in self._value[0])
+        kwargs = {key: value._construct(constructor) for key, value in self._value[1].items()}
         assert args or kwargs, "Error converting Args node to python"  # This should never happen
         if args and kwargs or always_pair:
             return args, kwargs
         return args or kwargs
 
-    def dump(self, dumper: nip.dumper.Dumper):
+    def _dump(self, dumper: nip.dumper.Dumper):
         dumped_args = "\n".join(
-            [" " * dumper.indent + f"- {item.dump(dumper + dumper.default_shift)}" for item in self.value[0]]
+            [" " * dumper.indent + f"- {item._dump(dumper + dumper.default_shift)}" for item in self._value[0]]
         )
         string = ("\n" if dumped_args else "") + dumped_args
 
         dumped_kwargs = "\n".join(
             [
-                " " * dumper.indent + f"{key}: {value.dump(dumper + dumper.default_shift)}"
-                for key, value in self.value[1].items()
+                " " * dumper.indent + f"{key}: {value._dump(dumper + dumper.default_shift)}"
+                for key, value in self._value[1].items()
             ]
         )
         string += ("\n" if dumped_kwargs else "") + dumped_kwargs
 
         return string
 
+    def _update_parents(self):
+        self.__dict__.update(self._value[1])
+        for item in self:
+            item._parent = self
+            item._update_parents()
 
-class Iter(Element):
+
+class Iter(Node):  # mark all parents as Iterable and allow construct specific instance
     def __init__(self, name: str = "", value: Any = None):
         super(Iter, self).__init__(name, value)
-        self.return_index = -1
+        self._return_index = -1
         # mb: name all the iterators and get the value from constructor rather then use this index
 
     @classmethod
@@ -415,72 +467,72 @@ class Iter(Element):
         if read_tokens is None:
             return None
         stream.step()
-        value = RightValue.read(stream, parser)
-        if isinstance(value, Value) and isinstance(value.value, list):
-            value = value.value
-        elif isinstance(value, Args) and len(value.value[1]) == 0:
+        value = read_node(stream, parser)
+        if isinstance(value, Value) and isinstance(value._value, list):
+            value = value._value
+        elif isinstance(value, Args) and len(value._value[1]) == 0:
             value = value
         else:
             raise nip.parser.ParserError(stream, "List is expected as a value for Iterable node")
         if len(read_tokens) == 1:
             iterator = Iter("", value)
         else:
-            iterator = Iter(read_tokens[1].value, value)
+            iterator = Iter(read_tokens[1]._value, value)
 
         parser.iterators.append(iterator)
         return iterator
 
     def to_python(self):
-        if self.return_index == -1:
-            raise iter(self.value)
-        if isinstance(self.value[self.return_index], Element):
-            return self.value[self.return_index].to_python()
-        return self.value[self.return_index]
+        if self._return_index == -1:
+            raise iter(self._value)
+        if isinstance(self._value[self._return_index], Node):
+            return self._value[self._return_index].to_python()
+        return self._value[self._return_index]
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        if self.return_index == -1:
+    def _construct(self, constructor: nip.constructor.Constructor):
+        if self._return_index == -1:
             raise Exception("Iterator index was not specified by IterParser")
-        if isinstance(self.value, list):
-            return self.value[self.return_index]
-        elif isinstance(self.value, Args):
-            return self.value[self.return_index].construct(constructor)
+        if isinstance(self._value, list):
+            return self._value[self._return_index]
+        elif isinstance(self._value, Args):
+            return self._value[self._return_index]._construct(constructor)
         else:
             raise nip.constructor.ConstructorError(self, (), {}, "Unexpected iter value type")
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        if self.return_index == -1:
+    def _dump(self, dumper: nip.dumper.Dumper):
+        if self._return_index == -1:
             raise nip.dumper.DumpError("Dumping an iterator but index was not specified by IterParser")
-        if isinstance(self.value, list):
-            return str(self.value[self.return_index])
-        elif isinstance(self.value, Args):
-            return self.value[self.return_index].dump(dumper)
+        if isinstance(self._value, list):
+            return str(self._value[self._return_index])
+        elif isinstance(self._value, Args):
+            return self._value[self._return_index]._dump(dumper)
         else:
             raise nip.dumper.DumpError("Unable to dump Iterable node: unexpected value type")
 
 
-class InlinePython(Element):
+class InlinePython(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[InlinePython, None]:
         read_tokens = stream.peek(tokens.InlinePython)
         if read_tokens is None:
             return None
         stream.step()
-        exec_string = read_tokens[0].value
+        exec_string = read_tokens[0]._value
         return InlinePython(value=exec_string)
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        nsc.preload_vars(self.value, constructor)
+    def _construct(self, constructor: nip.constructor.Constructor):
+        nsc.preload_vars(self._value, constructor)
         locals().update(constructor.vars)
-        return eval(self.value)
+        return eval(self._value)
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return f"`{self.value}`"
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return f"`{self._value}`"
 
     def to_python(self):
-        return f"`{self.value}`"
+        return f"`{self._value}`"
 
 
-class Nothing(Element):
+class Nothing(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[Nothing, None]:
         if not stream:
@@ -490,51 +542,72 @@ class Nothing(Element):
         if stream.pos == 0 or (stream.lines[stream.n][: stream.pos].isspace() and indent <= parser.last_indent):
             return Nothing()
 
-    def construct(self, constructor: nip.constructor.Constructor):
+    def _construct(self, constructor: nip.constructor.Constructor):
         return self
 
-    def dump(self, dumper: nip.dumper.Dumper):
+    def _dump(self, dumper: nip.dumper.Dumper):
         return ""
 
     def to_python(self):
         return None
 
 
-class FString(Element):  # Includes f-string and r-string
+class FString(Node):  # Includes f-string and r-string
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[FString, None]:
         read_tokens = stream.peek(tokens.PythonString)
         if read_tokens is None:
             return None
         stream.step()
-        string, t = read_tokens[0].value
+        string, t = read_tokens[0]._value
         if t == "r":
             print(
                 "Warning: all strings in NIP are already python r-string. " "You don't have to explicitly specify it."
             )
         return FString(value=string)
 
-    def construct(self, constructor: nip.constructor.Constructor):
-        nsc.preload_vars(f"f{self.value}", constructor)
+    def _construct(self, constructor: nip.constructor.Constructor):
+        nsc.preload_vars(f"f{self._value}", constructor)
         locals().update(constructor.vars)
-        return eval(f"f{self.value}")
+        return eval(f"f{self._value}")
 
-    def dump(self, dumper: nip.dumper.Dumper):
-        return f"f{self.value}"
+    def _dump(self, dumper: nip.dumper.Dumper):
+        return f"f{self._value}"
 
     def to_python(self):
-        return f"f{self.value}"
+        return f"f{self._value}"
 
 
-class Directive(Element):
+class Directive(Node):
     @classmethod
     def read(cls, stream: nip.stream.Stream, parser: nip.parser.Parser) -> Union[FString, None]:
         read_tokens = stream.peek(tokens.Operator("!!"), tokens.Name)
         if read_tokens is None:
             return None
-        name = read_tokens[1].value
+        name = read_tokens[1]._value
         stream.step()
 
-        value = RightValue.read(stream, parser)
+        value = read_node(stream, parser)
 
         return nip.directives.call_directive(name, value, stream)
+
+
+def read_node(stream: nip.stream.Stream, parser: nip.parser.Parser) -> Node:
+    value = (
+        Directive.read(stream, parser)
+        or LinkCreation.read(stream, parser)
+        or Link.read(stream, parser)
+        or Class.read(stream, parser)
+        or Tag.read(stream, parser)
+        or Iter.read(stream, parser)
+        or Args.read(stream, parser)
+        or FString.read(stream, parser)
+        or Nothing.read(stream, parser)
+        or InlinePython.read(stream, parser)
+        or Value.read(stream, parser)
+    )
+
+    if value is None:
+        raise nip.parser.ParserError(stream, "Wrong right value")
+
+    return value

--- a/nip/elements.py
+++ b/nip/elements.py
@@ -42,7 +42,7 @@ class Node(ABC, object):
             return self
         return self._value[item]
 
-    def __getattr__(self, item):
+    def __getattr__(self, item):  # unable to access names like `construct` and 'dump` via this method
         return self.__getitem__(item)
 
     def __setitem__(self, key, value):
@@ -63,10 +63,6 @@ class Node(ABC, object):
 
     def construct(self, base_config: Node = None, strict_typing: bool = False, nonsequential: bool = True):
         return nip.construct(self, base_config=base_config, strict_typing=strict_typing, nonsequential=nonsequential)
-
-    @property
-    def value(self):
-        return self.construct()
 
     def _dump(self, dumper: nip.dumper.Dumper):
         return self._value._dump(dumper)

--- a/nip/iter_parser.py
+++ b/nip/iter_parser.py
@@ -2,34 +2,34 @@ from collections import defaultdict
 from itertools import product
 from typing import Iterable
 
-from .elements import Element
+from .elements import Node
 from .parser import Parser
 
 
 class IterParser:  # mb: insert this functionality into Parser (save parsed tree in Parser)
-    def __init__(self, parser: Parser, element: Element = None):
+    def __init__(self, parser: Parser, element: Node = None):
         self.iterators = parser.iterators
         self.element = element
 
-    def iter_configs(self, element: Element) -> Iterable[Element]:
+    def iter_configs(self, element: Node) -> Iterable[Node]:
         iter_groups = defaultdict(list)
         for i, iterator in enumerate(self.iterators):
-            name = iterator.name if iterator.name else f"_{i}"
+            name = iterator._name if iterator._name else f"_{i}"
             iter_groups[name].append(iterator)
         for group_name, group in iter_groups.items():
-            iter_len = len(group[0].value)
+            iter_len = len(group[0]._value)
             for iterator in group:
-                if len(iterator.value) != iter_len:
+                if len(iterator._value) != iter_len:
                     raise IterParserError(f"Iterators of group '{group_name}' have different lengths")
 
         group_names = sorted(iter_groups.keys())
-        group_lengths = [len(iter_groups[name][0].value) for name in group_names]
+        group_lengths = [len(iter_groups[name][0]._value) for name in group_names]
         index_sets = product(*(range(length) for length in group_lengths))
 
         for indexes in index_sets:
             for index, group_name in zip(indexes, group_names):
                 for iterator in iter_groups[group_name]:
-                    iterator.return_index = index
+                    iterator._return_index = index
             yield element
 
     def __iter__(self):

--- a/nip/main.py
+++ b/nip/main.py
@@ -191,6 +191,7 @@ def dump(path: Union[str, Path], obj: Union[elements.Node, object]):
     """
     if not isinstance(obj, elements.Node):
         obj = convert(obj)
+        # mb: wrap with Document to ensure getting `---` at the beginning of the file.
     dumper = Dumper()
     dumper.dump(path, obj)
 

--- a/nip/main.py
+++ b/nip/main.py
@@ -27,7 +27,7 @@ def parse(
     always_iter: bool = False,
     implicit_fstrings: bool = True,
     strict: bool = False,
-) -> Union[elements.Element, Iterable[elements.Element]]:
+) -> Union[elements.Node, Iterable[elements.Node]]:
     """Parses config providing Element tree
 
     Parameters
@@ -57,7 +57,7 @@ def parse_string(
     always_iter: bool = False,
     implicit_fstrings: bool = True,
     strict: bool = False,
-) -> Union[elements.Element, Iterable[elements.Element]]:
+) -> Union[elements.Node, Iterable[elements.Node]]:
     """Parses config providing Element tree
 
     Parameters
@@ -83,10 +83,10 @@ def parse_string(
 
 
 def construct(
-    config: elements.Element,
-    base_config: elements.Element = None,
+    config: elements.Node,
+    base_config: elements.Node = None,
     strict_typing: bool = False,
-    nonsequential: bool = False,
+    nonsequential: bool = True,
 ) -> Any:
     """Constructs python object based on config and known nip-objects
 
@@ -107,7 +107,7 @@ def construct(
     obj: Any
     """
     if nonsequential or base_config is not None:
-        base_config = base_config or config
+        base_config = base_config or config._get_root()
         constructor = NonSequentialConstructor(base_config, strict_typing=strict_typing)
     else:
         constructor = Constructor(strict_typing=strict_typing)
@@ -179,7 +179,7 @@ def load_string(
     return construct(config, strict_typing=strict, nonsequential=nonsequential)
 
 
-def dump(path: Union[str, Path], obj: Union[elements.Element, object]):
+def dump(path: Union[str, Path], obj: Union[elements.Node, object]):
     """Dumps config tree to file.
 
     Parameters
@@ -189,13 +189,13 @@ def dump(path: Union[str, Path], obj: Union[elements.Element, object]):
     obj: Element or object
         Read or generated config if Element. In case of any other object `convert` will be called.
     """
-    if not isinstance(obj, elements.Element):
+    if not isinstance(obj, elements.Node):
         obj = convert(obj)
     dumper = Dumper()
     dumper.dump(path, obj)
 
 
-def dump_string(obj: Union[elements.Element, object]) -> str:
+def dump_string(obj: Union[elements.Node, object]) -> str:
     """Dumps config tree to string.
 
     Parameters
@@ -208,7 +208,7 @@ def dump_string(obj: Union[elements.Element, object]) -> str:
     string: str
         Dumped element as a string.
     """
-    if not isinstance(obj, elements.Element):
+    if not isinstance(obj, elements.Node):
         obj = convert(obj)
     dumper = Dumper()
     return dumper.dumps(obj)

--- a/nip/non_seq_constructor.py
+++ b/nip/non_seq_constructor.py
@@ -19,7 +19,7 @@ class VarsDict:
         if item in self.in_progress:
             raise NonSequentialConstructorError(f"Recursive construction of '{item}'.")
         self.in_progress.add(item)
-        self.constructor.links[item].construct(self.constructor)
+        self.constructor.links[item]._construct(self.constructor)
         self.in_progress.remove(item)
         return self.vars[item]
 
@@ -40,7 +40,7 @@ class VarsDict:
 class NonSequentialConstructor(Constructor):
     def __init__(
         self,
-        base_config: "nip.elements.Element",
+        base_config: "nip.elements.Node",
         ignore_rewriting=False,
         load_builders=True,
         strict_typing=False,
@@ -50,15 +50,15 @@ class NonSequentialConstructor(Constructor):
         self.links = {}
         self._find_links(base_config)
 
-    def _find_links(self, node: "nip.elements.Element"):
+    def _find_links(self, node: "nip.elements.Node"):
         if isinstance(node, nip.elements.LinkCreation):
-            assert node.name not in self.links, "Redefined link."
-            self.links[node.name] = node
+            assert node._name not in self.links, "Redefined link."
+            self.links[node._name] = node
         if isinstance(node, nip.elements.Args):
             for sub_node in node:
                 self._find_links(sub_node)
-        if isinstance(node.value, nip.elements.Element):
-            self._find_links(node.value)
+        if isinstance(node._value, nip.elements.Node):
+            self._find_links(node._value)
 
 
 class NonSequentialConstructorError(Exception):

--- a/nip/parser.py
+++ b/nip/parser.py
@@ -5,7 +5,7 @@ import nip.elements as elements
 from .stream import Stream
 
 
-class Parser:  # mb: we don't need Parser itself. its just storage for links and tags. Hm...
+class Parser:
     def __init__(
         self,
         implicit_fstrings: bool = True,
@@ -19,13 +19,16 @@ class Parser:  # mb: we don't need Parser itself. its just storage for links and
         self.strict = strict
         self.sequential_links = sequential_links
         self.last_indent = -1
+        self.stack = []
 
     def parse(self, path: Union[str, Path]):
         path = Path(path)
         with path.open() as f_stream:
             string_representation = f_stream.read()
 
-        return self.parse_string(string_representation)
+        tree = self.parse_string(string_representation)
+        tree._path = path
+        return tree
 
     def __call__(self, path: Union[str, Path]):
         return self.parse(path)
@@ -35,6 +38,7 @@ class Parser:  # mb: we don't need Parser itself. its just storage for links and
         tree = elements.Document.read(stream, self)
         if stream:
             raise ParserError(stream, "Wrong statement.")
+        tree._update_parents()
         return tree
 
     def has_iterators(self) -> bool:

--- a/nip/tokens.py
+++ b/nip/tokens.py
@@ -8,7 +8,7 @@ class Token(ABC):
     """Abstract of token reader"""
 
     def __init__(self, value: Any = None):
-        self.value = value
+        self._value = value
 
     @staticmethod
     @abstractmethod
@@ -20,10 +20,10 @@ class Token(ABC):
         self.pos = pos
 
     def __eq__(self, other: Token):
-        return self.__class__ == other.__class__ and self.value == other.value
+        return self.__class__ == other.__class__ and self._value == other._value
 
     @property
-    def name(self):
+    def _name(self):
         return self.__class__.__name__
 
 
@@ -127,24 +127,7 @@ class Name(String):
 
 
 class Operator(Token):
-    operators = [
-        "---",
-        "@",
-        "#",
-        "&",
-        "!&",
-        "!!",
-        "!",
-        "- ",
-        ": ",
-        "*",
-        "{",
-        "}",
-        "[",
-        "]",
-        "(",
-        ")",
-    ]
+    operators = ["---", "@", "#", "&", "!&", "!!", "!", "- ", ": ", "*", "{", "}", "[", "]", "(", ")"]
 
     @staticmethod
     def read(stream: str) -> Tuple[int, Union[None, Operator]]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nip-config
-version = 0.10.4
+version = 0.11.0
 author = Ilya Vasiliev
 author_email = spairet@bk.ru
 description = Advanced configs for python

--- a/tests/base_tests/document/test_document.py
+++ b/tests/base_tests/document/test_document.py
@@ -5,7 +5,7 @@ def test_document():
 
     parsed = parse("base_tests/document/configs/document.nip")
     assert isinstance(parsed, Document)
-    assert parsed.name == "Strange_and_2_long_DocumentName"
+    assert parsed._name == "Strange_and_2_long_DocumentName"
 
     result = load("base_tests/document/configs/document.nip")
     assert isinstance(result, builders.MyClass)

--- a/tests/features/non_seq/configs/harder_non_seq.nip
+++ b/tests/features/non_seq/configs/harder_non_seq.nip
@@ -8,5 +8,5 @@ main:
       - 7
 
 other_main:
-  iteresting: *it
+  interesting: *it
   here_is_the_ll: &ll 6

--- a/tests/features/non_seq/test_non_seq.py
+++ b/tests/features/non_seq/test_non_seq.py
@@ -31,7 +31,7 @@ def test_harder_non_seq():
             }
         ],
         'other_main': {
-            'iteresting': [4, 5, 6, 7],
+            'interesting': [4, 5, 6, 7],
             'here_is_the_ll': 6
         }
     }
@@ -42,13 +42,16 @@ def test_part_harder_non_seq():
     config = nip.parse("features/non_seq/configs/harder_non_seq.nip")
     constructor = nip.non_seq_constructor.NonSequentialConstructor(config)
     expected = {
-        'iteresting': [4, 5, 6, 7],
+        'interesting': [4, 5, 6, 7],
         'here_is_the_ll': 6
     }
     output = constructor.construct(config['other_main'])
     assert output == expected
 
-    output = config['other_main'].construct(constructor)
+    output = config['other_main']._construct(constructor)
+    assert output == expected
+
+    output = nip.construct(config['other_main'])
     assert output == expected
 
 

--- a/tests/features/object_dump/dumps/no_default.nip
+++ b/tests/features/object_dump/dumps/no_default.nip
@@ -1,0 +1,8 @@
+!NoDefaultDumper 
+- "just_a_name"
+value: !BigComplexClass 
+  - "data_value"
+  - 
+    - 1
+    - 2
+    - 3

--- a/tests/features/object_dump/some_classes.py
+++ b/tests/features/object_dump/some_classes.py
@@ -29,3 +29,9 @@ class SmallButValuableClass:
 
     def __nip__(self):
         return self.just_name
+
+
+class NoDefaultDumper:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value

--- a/tests/features/object_dump/test_dump.py
+++ b/tests/features/object_dump/test_dump.py
@@ -1,11 +1,9 @@
 def test_base():
     from nip import dump, load
-    obj = {
-        'first': 1,
-        'second': '2'
-    }
-    dump('features/object_dump/dumps/obj.nip', obj)
-    assert load('features/object_dump/dumps/obj.nip') == obj
+
+    obj = {"first": 1, "second": "2"}
+    dump("features/object_dump/dumps/obj.nip", obj)
+    assert load("features/object_dump/dumps/obj.nip") == obj
 
 
 def test_complex():
@@ -14,12 +12,23 @@ def test_complex():
 
     small_obj_1 = SmallButValuableClass("Popo")
     small_obj_2 = SmallButValuableClass("Pepe")
-    big_obj = BigComplexClass({'dict': 'with', 'some': 'data', 'number': 42},
-                              childs=[small_obj_1, small_obj_2])
+    big_obj = BigComplexClass({"dict": "with", "some": "data", "number": 42}, childs=[small_obj_1, small_obj_2])
     dump("features/object_dump/dumps/complex.nip", big_obj)
     result = load("features/object_dump/dumps/complex.nip")
-    assert result.data == {'dict': 'with', 'some': 'data', 'number': 42}
-    assert isinstance(result.childs[0], SmallButValuableClass) and \
-           result.childs[0].just_name == 'Popo'
-    assert isinstance(result.childs[1], SmallButValuableClass) and \
-           result.childs[1].just_name == 'Pepe'
+    assert result.data == {"dict": "with", "some": "data", "number": 42}
+    assert isinstance(result.childs[0], SmallButValuableClass) and result.childs[0].just_name == "Popo"
+    assert isinstance(result.childs[1], SmallButValuableClass) and result.childs[1].just_name == "Pepe"
+
+
+def test_no_defalut_dumper():
+    import some_classes
+    import nip
+
+    nip.nip(some_classes, convertable=True)
+    value = some_classes.BigComplexClass("data_value", [1, 2, 3])
+    obj = some_classes.NoDefaultDumper("just_a_name", value=value)
+    nip.dump("features/object_dump/dumps/no_default.nip", obj)
+    result = nip.load("features/object_dump/dumps/no_default.nip")
+    assert isinstance(result, some_classes.NoDefaultDumper)
+    assert isinstance(result.value, some_classes.BigComplexClass)
+    assert result.value.data == "data_value" and result.value.childs == [1, 2, 3]

--- a/tests/utils/builders.py
+++ b/tests/utils/builders.py
@@ -37,8 +37,8 @@ def NoNipFunc(name):
 
 
 def show(*args, **kwargs):
-    print('args:', args)
-    print('kwargs:', kwargs)
+    print("args:", args)
+    print("kwargs:", kwargs)
 
 
 def main(param, config):
@@ -64,7 +64,7 @@ class Note:
         return self.name == other.name and self.comment == other.comment
 
 
-@nip(['first_tag', 'second_tag'])
+@nip(["first_tag", "second_tag"])
 class MultiTagClass:
-    def __init__(self, name: str = ''):
+    def __init__(self, name: str = ""):
         self.name = name

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -21,9 +21,12 @@ def deep_conditioned_compare(first: object, second: object, conditions: List[Cal
     if isinstance(first, (list, tuple)) and isinstance(second, (list, tuple)):
         if len(first) != len(second):
             return False
-        return all([deep_conditioned_compare(first_item, second_item, conditions)
-                    for first_item, second_item
-                    in zip(first, second)])
+        return all(
+            [
+                deep_conditioned_compare(first_item, second_item, conditions)
+                for first_item, second_item in zip(first, second)
+            ]
+        )
     if isinstance(first, dict) and isinstance(second, dict):
         if len(first) != len(second):
             return False


### PR DESCRIPTION
Added items access via dots. convenient construction and dumping with nonsequential=True as defult.
Example:
```
config = nip.parse("experiment_config.nip")
model = config.model.construct()
config.model.encoder.dump("encoder_config.nip")
```

example of conversion and update:
```
@nip.nip(convertable=True)
class MyCoolModel:
    ...
    
model = MyCoolModel(arg1, arg2, kwarg1=kwarg1)

# just dump the config of the model
nip.dump("model_config.nip", model)  

# add as a part to other config
config = nip.parse("experiment_config.nip")
config.model = model
config.update()
```